### PR TITLE
Change how icons are loaded/hidden, fixed a bug with the settings icon when material icons could not be loaded.

### DIFF
--- a/static/css/style.css
+++ b/static/css/style.css
@@ -59,6 +59,7 @@
     line-height: 1;
     letter-spacing: normal;
     text-transform: none;
+    visibility: hidden; /* will be set to visible if icon pack can be loaded. */
     display: inline-block;
     white-space: nowrap;
     word-wrap: normal;
@@ -75,19 +76,15 @@
     top: 6px;
     right: 10px;
     cursor: pointer;
-    visibility: hidden;
-    /* will be set to visible if icon pack can be loaded. */
 }
 
 #sub-search-wrapper-ico {
     background: none;
     border: none;
     cursor: pointer;
-    font-size: 0px;
+    font-size: 0px; /* will be set to 17px if icon pack can be loaded. */
     padding-right: 0px;
     margin-right: 0px;
-    visibility: hidden;
-    /* will be set to visible if icon pack can be loaded. */
 }
 
 .fetched_dif {

--- a/static/script.js
+++ b/static/script.js
@@ -125,10 +125,15 @@ document.addEventListener('click', (event) => {
 // skip them and put a warning in the console.
 const font = new FontFace('Material Icons Round', 'url("/fonts/material-icons-round-v108-latin-regular.woff2") format("woff2")');
 font.load().then(() => {
-  document.querySelector("#search-wrapper-ico").style.visibility = 'visible';
+  const icons = document.getElementsByClassName('material-icons-round');
+
+  // Display all icons.
+  for (let icon of icons) {
+    icon.style.visibility = 'visible';
+  }
+
+  // Ensure icons for the different types of searches are sized correctly.
   document.querySelectorAll('#sub-search-wrapper-ico').forEach((el) => {
-    // Show the icon if the font successfully loaded.
-    el.style.visibility = 'visible';
     el.style.fontSize = '17px';
   });
 }).catch(() => {
@@ -145,12 +150,12 @@ window.addEventListener('DOMContentLoaded', function() {
     const pageId = Object.keys(data.query.pages)[0];
     const thumbnailSource = data.query.pages[pageId].thumbnail.source;
     const url = "/img_proxy?url=" + thumbnailSource;
-    
+
     // update the img tag with url and add kno_wiki_show
     var imgElement = document.querySelector('.kno_wiki');
     imgElement.src = url;
     imgElement.classList.add('kno_wiki_show');
-    
+
     console.log(url);
   })
   .catch(error => {


### PR DESCRIPTION
If material icons could not be loaded (either by the server not having the icons or the client rejecting them), "tune" would appear in-place of the settings icon (the one to the right of the search bar).

This PR fixes that bug by hiding that icon's name (with every other icon that is usually hidden) if the icons could not be loaded. It does this by hiding every element in the `material-icons-round` CSS class, only showing elements in that class when the pack could be loaded.