### PR TITLE
Always ignore `__pycache__` directory, regardless of location.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 __pycache__
+**/__pycache__


### PR DESCRIPTION
In response to https://github.com/Extravi/tailsx/commit/85b10c282cf3f04877c4f22b1b048022c99096f6. `.gitignore` will now tell git to ignore the `__pycache__` directory, regardless of where it lives.