### PR TITLE
Keep the type of search with the Next and Previous buttons at the bottom of the results page.

### DIFF
--- a/templates/results.html
+++ b/templates/results.html
@@ -114,12 +114,16 @@
         {% endfor %}
     </div>
     <div class="prev-next">
-        {% set p = request.args.get('p', 0)|int %}
-        {% if p >= 10 %}
-            <button form="prev-next-form" name="p" value="{{ p - 10 }}">Previous</button>
-        {% endif %}
-        <button form="prev-next-form" name="p" value="{{ p + 10 }}">Next</button>
-    </div>    
+        <form action="">
+          <input type="hidden" name="q" value="{{ q }}">
+          <input type="hidden" name="t" value="{{ type }}">
+          {% set p = request.args.get('p', 0)|int %}
+          {% if p >= 10 %}
+              <button name="p" value="{{ p - 10 }}">Previous</button>
+          {% endif %}
+          <button name="p" value="{{ p + 10 }}">Next</button>
+        </form>
+    </div>
     {% else %}
         <div class="no-results-found">
             Your search '{{ q }}' came back with no results.<br>

--- a/templates/results.html
+++ b/templates/results.html
@@ -114,7 +114,7 @@
         {% endfor %}
     </div>
     <div class="prev-next">
-        <form action="">
+        <form>
           <input type="hidden" name="q" value="{{ q }}">
           <input type="hidden" name="t" value="{{ type }}">
           {% set p = request.args.get('p', 0)|int %}


### PR DESCRIPTION
When you click on the buttons at the bottom of the page, it removes the search type. 
For example, if you're on the `reddit` search type and click the buttons at the bottom, it sends you to the default search type, which is `text`.