### PR TITLE
Only load calculator.js if it's needed

### DIFF
--- a/templates/results_layout.html
+++ b/templates/results_layout.html
@@ -18,7 +18,7 @@
         <link rel="stylesheet" href="./css/{{ theme }}.css">
     {% endif %}
     <link rel="stylesheet" type="text/css" href="{{ url_for('static', filename='css/style.css') }}">
-    <link rel="search" type="application/opensearchdescription+xml" href="url_for('static', filename='opensearch.xml') }}" title="TailsX">
+    <link rel="search" type="application/opensearchdescription+xml" href="{{ url_for('static', filename='opensearch.xml') }}" title="TailsX">
     <meta http-equiv="Content-Security-Policy" content="default-src 'self';">
     <meta http-equiv="Strict-Transport-Security" content="max-age=63072000; includeSubDomains">
 </head>

--- a/templates/results_layout.html
+++ b/templates/results_layout.html
@@ -101,12 +101,9 @@
         {% if javascript == "enabled" %}
         <div id="kno_title" data-kno-title="{{ kno_title }}"></div>
         <script defer src="/script.js"></script>
-        {% endif %}
-        {% if calc == "" %}
-        {% else %}
-        {% if javascript == "enabled" %}
-        <script defer src="/calculator.js"></script>
-        {% endif %}
+          {% if not calc == "" and type == "text" %}
+          <script defer src="/calculator.js"></script>
+          {% endif %}
         {% endif %}
     </form>
     {% block body %}{% endblock %}


### PR DESCRIPTION
First commit stops `calculator.js` from loading unless it's needed.
The second fixes a syntax error in how the opensearch.xml file is loaded.