### PR TITLE
Add nyaa.si for torrents, and make it easier for adding new torrent sites in the future.

### DIFF
--- a/_config.py
+++ b/_config.py
@@ -72,5 +72,10 @@ API_ENABLED = False
 # set to false to disable torrent search
 TORRENTSEARCH_ENABLED = True
 
+ENABLED_TORRENT_SITES = [
+    "nyaa",
+    "torrentgalaxy"
+]
+
 # if you are using a custom Invidious you have to add it to the whitelist above
 INVIDIOUS_INSTANCE = "yt.artemislena.eu"

--- a/_config.py
+++ b/_config.py
@@ -17,6 +17,7 @@ PORT = 8000
 
 # Torrent domains
 TORRENTGALAXY_DOMAIN = "torrentgalaxy.to"
+NYAA_DOMAIN = "nyaa.si"
 
 # Useragents to use in the request.
 user_agents = [
@@ -59,7 +60,8 @@ WHITELISTED_DOMAINS = [
     "wikipedia.org",
     "yt.artemislena.eu",
     "lite.qwant.com",
-    TORRENTGALAXY_DOMAIN
+    TORRENTGALAXY_DOMAIN,
+    NYAA_DOMAIN,
 ]
 
 COOKIE_AGE = 2147483647

--- a/src/torrent_sites/nyaa.py
+++ b/src/torrent_sites/nyaa.py
@@ -1,7 +1,11 @@
 from _config import *
 from src import helpers
 
-def nyaa(query):
+
+def name():
+    return "nyaa"
+
+def search(query):
     soup = helpers.makeHTMLRequest(f"https://{NYAA_DOMAIN}/?f=0&c=0_0&q={query}")
     results = []
     for torrent in soup.select(".default, .success, .danger"):

--- a/src/torrent_sites/nyaa.py
+++ b/src/torrent_sites/nyaa.py
@@ -12,7 +12,7 @@ def nyaa(query):
             "title": list_of_anchors[1].get_text().strip(),
             "magnet": list_of_anchors[1]["href"],
             "size": text_center[1].get_text().strip(),
-            "views": int(text_center[5].get_text().strip()),
+            "views": None,
             "seeders": int(text_center[3].get_text().strip()),
             "leechers": int(text_center[4].get_text().strip())
         })

--- a/src/torrent_sites/nyaa.py
+++ b/src/torrent_sites/nyaa.py
@@ -1,0 +1,19 @@
+from _config import *
+from src import helpers
+
+def nyaa(query):
+    soup = helpers.makeHTMLRequest(f"https://{NYAA_DOMAIN}/?f=0&c=0_0&q={query}")
+    results = []
+    for torrent in soup.select(".default, .success, .danger"):
+        list_of_anchors = torrent.select("a")
+        text_center = torrent.select(".text-center")
+        results.append({
+            "href": NYAA_DOMAIN,
+            "title": list_of_anchors[1].get_text().strip(),
+            "magnet": list_of_anchors[1]["href"],
+            "size": text_center[1].get_text().strip(),
+            "views": int(text_center[5].get_text().strip()),
+            "seeders": int(text_center[3].get_text().strip()),
+            "leechers": int(text_center[4].get_text().strip())
+        })
+    return results

--- a/src/torrent_sites/torrentgalaxy.py
+++ b/src/torrent_sites/torrentgalaxy.py
@@ -1,0 +1,39 @@
+from _config import *
+from src import helpers
+
+def torrentgalaxy():
+    soup = helpers.makeHTMLRequest(f"https://{TORRENTGALAXY_DOMAIN}/torrents.php?search={query}#results")
+
+    result_divs = soup.findAll("div", {"class": "tgxtablerow"})
+    title = [div.find("div", {"id": "click"}) for div in result_divs]
+    title = [title.text.strip() for title in title]
+    hrefs = [TORRENTGALAXY_DOMAIN for title in title]
+    magnet_links = [
+        div.find("a", href=lambda href: href and href.startswith("magnet")).get("href")
+        for div in result_divs
+    ]
+    file_sizes = [
+        div.find("span", {"class": "badge-secondary"}).text.strip()
+        for div in result_divs
+    ]
+    view_counts = [div.find("font", {"color": "orange"}).text.strip() for div in result_divs]
+    seeders = [div.find("font", {"color": "green"}).text.strip() for div in result_divs]
+    leechers = [div.find("font", {"color": "#ff0000"}).text.strip() for div in result_divs]
+
+    # list
+    results = []
+    for href, title, magnet_link, file_size, view_count, seeder, leecher in zip(
+        hrefs, title, magnet_links, file_sizes, view_counts, seeders, leechers):
+        results.append(
+            {
+                "href": href,
+                "title": title,
+                "magnet": magnet_link,
+                "size": file_size,
+                "views": view_count,
+                "seeders": seeder,
+                "leechers": leecher
+            }
+        )
+
+    return results

--- a/src/torrent_sites/torrentgalaxy.py
+++ b/src/torrent_sites/torrentgalaxy.py
@@ -16,9 +16,9 @@ def torrentgalaxy():
         div.find("span", {"class": "badge-secondary"}).text.strip()
         for div in result_divs
     ]
-    view_counts = [div.find("font", {"color": "orange"}).text.strip() for div in result_divs]
-    seeders = [div.find("font", {"color": "green"}).text.strip() for div in result_divs]
-    leechers = [div.find("font", {"color": "#ff0000"}).text.strip() for div in result_divs]
+    view_counts = [int(div.find("font", {"color": "orange"}).text) for div in result_divs]
+    seeders = [int(div.find("font", {"color": "green"}).text) for div in result_divs]
+    leechers = [int(div.find("font", {"color": "#ff0000"}).text) for div in result_divs]
 
     # list
     results = []

--- a/src/torrent_sites/torrentgalaxy.py
+++ b/src/torrent_sites/torrentgalaxy.py
@@ -1,7 +1,10 @@
 from _config import *
 from src import helpers
 
-def torrentgalaxy():
+def name():
+    return "torrentgalaxy"
+
+def search():
     soup = helpers.makeHTMLRequest(f"https://{TORRENTGALAXY_DOMAIN}/torrents.php?search={query}#results")
 
     result_divs = soup.findAll("div", {"class": "tgxtablerow"})

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -16,7 +16,7 @@ def torrentResults(query) -> Response:
     query = request.args.get("q", " ").strip()
 
     sites = [
-        # torrentgalaxy.torrentgalaxy,
+        torrentgalaxy.torrentgalaxy,
         nyaa.nyaa
     ]
 

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -1,50 +1,46 @@
-from src.helpers import makeHTMLRequest, latest_commit
+import time
+from src.helpers import latest_commit
 from _config import *
 from flask import request, render_template, jsonify, Response
-import time
+from src.torrent_sites import torrentgalaxy, nyaa
 
 
 def torrentResults(query) -> Response:
-    if TORRENTSEARCH_ENABLED == False:
+    if not TORRENTSEARCH_ENABLED:
         return jsonify({"error": "Torrent search disabled by instance operator"}), 503
-    else:
 
-        # remember time we started
-        start_time = time.time()
+    # remember time we started
+    start_time = time.time()
 
-        api = request.args.get("api", "false")
+    api = request.args.get("api", "false")
+    query = request.args.get("q", " ").strip()
 
-        # grab & format webpage
-        soup = makeHTMLRequest(f"https://{TORRENTGALAXY_DOMAIN}/torrents.php?search={query}#results")
+    sites = [
+        # torrentgalaxy.torrentgalaxy,
+        nyaa.nyaa
+    ]
 
-        result_divs = soup.findAll("div", {"class": "tgxtablerow"})
-        title = [div.find("div", {"id": "click"}) for div in result_divs]
-        title = [title.text.strip() for title in title]
-        hrefs = ["torrentgalaxy.to" for title in title]
-        magnet_links = [div.find("a", href=lambda href: href and href.startswith("magnet")).get("href") for div in result_divs]
-        file_sizes = [div.find("span", {"class": "badge-secondary"}).text.strip() for div in result_divs]
-        view_counts = [div.find("font", {"color": "orange"}).text.strip() for div in result_divs]
-        seeders = [div.find("font", {"color": "green"}).text.strip() for div in result_divs]
-        leechers = [div.find("font", {"color": "#ff0000"}).text.strip() for div in result_divs]
+    results = []
+    for site in sites:
+        results += site(query)
 
-        # list
-        results = []
-        for href, title, magnet_link, file_size, view_count, seeder, leecher in zip(hrefs, title, magnet_links, file_sizes, view_counts, seeders, leechers):
-            results.append([href, title, magnet_link, file_size, view_count, seeder, leecher])
+    # Sorts based on how many seeders there are on a torrent.
+    results = sorted(results, key=lambda x: x["seeders"])[::-1]
 
-        # calc. time spent
-        end_time = time.time()
-        elapsed_time = end_time - start_time
 
-        if api == "true" and API_ENABLED == True:
-            # return the results list as a JSON response
-            return jsonify(results)
-        else:
-            return render_template("torrents.html",
-                                results=results, title=f"{query} - TailsX",
-                                q=f"{query}", fetched=f"Fetched the results in {elapsed_time:.2f} seconds",
-                                theme=request.cookies.get('theme', DEFAULT_THEME), DEFAULT_THEME=DEFAULT_THEME,
-                                javascript=request.cookies.get('javascript', 'enabled'), type="torrent",
-                                repo_url=REPO, API_ENABLED=API_ENABLED, TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED,
-                                commit=latest_commit()
-                                )
+    # calc. time spent
+    end_time = time.time()
+    elapsed_time = end_time - start_time
+
+    if api == "true" and API_ENABLED:
+        # return the results list as a JSON response
+        return jsonify(results)
+
+    return render_template("torrents.html",
+                        results=results, title=f"{query} - TailsX",
+                        q=f"{query}", fetched=f"Fetched the results in {elapsed_time:.2f} seconds",
+                        theme=request.cookies.get('theme', DEFAULT_THEME), DEFAULT_THEME=DEFAULT_THEME,
+                        javascript=request.cookies.get('javascript', 'enabled'), type="torrent",
+                        repo_url=REPO, API_ENABLED=API_ENABLED, TORRENTSEARCH_ENABLED=TORRENTSEARCH_ENABLED,
+                        commit=latest_commit()
+                        )

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -16,13 +16,15 @@ def torrentResults(query) -> Response:
     query = request.args.get("q", " ").strip()
 
     sites = [
-        torrentgalaxy.torrentgalaxy,
-        nyaa.nyaa
+        torrentgalaxy,
+        nyaa
     ]
 
     results = []
     for site in sites:
-        results += site(query)
+        if site.name() in ENABLED_TORRENT_SITES:
+            results += site.search(query)
+        # results += site(query)
 
     # Sorts based on how many seeders there are on a torrent.
     results = sorted(results, key=lambda x: x["seeders"])[::-1]

--- a/templates/torrents.html
+++ b/templates/torrents.html
@@ -6,10 +6,10 @@
     <div class="clean">
         {% for result in results %}
         <div class="results">
-            <a id="link" href="{{ result[2] }}">{{ result[0] }}</a>
-            <a class="torrent" href="{{ result[2] }}"><h3>{{ result[1] }}</h3></a>
-            <p class="stats">{{ result[4] }} views • {{ result[3] }}</p>
-            <p class="publish__info"> Seeders: <span class="seeders">{{ result[5] }}</span> <span class="pipe">|</span> Leechers: <span class="leechers">{{ result[6] }}</span></p>
+            <a id="link" href="{{ result["magnet"] }}">{{ result["href"] }}</a>
+            <a class="torrent" href="{{ result["magnet"] }}"><h3>{{ result["title"] }}</h3></a>
+            <p class="stats">{{ result["views"] }} views • {{ result["size"] }}</p>
+            <p class="publish__info"> Seeders: <span class="seeders">{{ result["seeders"] }}</span> <span class="pipe">|</span> Leechers: <span class="leechers">{{ result["leechers"] }}</span></p>
         </div>
         {% endfor %}
     </div>

--- a/templates/torrents.html
+++ b/templates/torrents.html
@@ -8,7 +8,7 @@
         <div class="results">
             <a id="link" href="{{ result["magnet"] }}">{{ result["href"] }}</a>
             <a class="torrent" href="{{ result["magnet"] }}"><h3>{{ result["title"] }}</h3></a>
-            <p class="stats">{{ result["views"] }} views • {{ result["size"] }}</p>
+            <p class="stats">{% if result["views"] is not None %}{{ result["views"] }} views • {% endif %}{{ result["size"] }}</p>
             <p class="publish__info"> Seeders: <span class="seeders">{{ result["seeders"] }}</span> <span class="pipe">|</span> Leechers: <span class="leechers">{{ result["leechers"] }}</span></p>
         </div>
         {% endfor %}


### PR DESCRIPTION
I haven't tested whether torrent galaxy works with this, since I my ISP blocks all its domains, and I don't have a VPN. I haven't changed much of its code, mainly just replacing the `results` array with a dict. So please do check if it still works.

The main change is that it's now easier to add new torrent sites (see nyaa.py), so the torrent page isn't solely dominated by one site.