### PR TITLE
Quote search query

### DIFF
--- a/src/images.py
+++ b/src/images.py
@@ -1,5 +1,5 @@
 from src.helpers import makeHTMLRequest, latest_commit
-from urllib.parse import unquote
+from urllib.parse import unquote, quote
 from _config import *
 from flask import request, render_template, jsonify, Response
 import time

--- a/src/images.py
+++ b/src/images.py
@@ -14,7 +14,7 @@ def imageResults(query) -> Response:
     api = request.args.get("api", "false")
 
     # grab & format webpage
-    soup = makeHTMLRequest(f"https://lite.qwant.com/?q={query}&t=images")
+    soup = makeHTMLRequest(f"https://lite.qwant.com/?q={quote(query)}&t=images")
 
     # get 'img' ellements
     ellements = soup.findAll("div", {"class": "images-container"})

--- a/src/textResults.py
+++ b/src/textResults.py
@@ -1,5 +1,5 @@
 from src.helpers import makeHTMLRequest, latest_commit
-from urllib.parse import unquote
+from urllib.parse import unquote, quote
 from _config import *
 from flask import request, render_template, jsonify, Response
 import time
@@ -25,9 +25,9 @@ def textResults(query) -> Response:
         if search_type == "reddit":
             site_restriction = "site:reddit.com"
             query_for_request = f"{query} {site_restriction}"
-            soup = makeHTMLRequest(f"https://www.{domain}&q={query_for_request}&start={p}&lr={lang}")
+            soup = makeHTMLRequest(f"https://www.{domain}&q={quote(query_for_request)}&start={p}&lr={lang}")
         elif search_type == "text":
-            soup = makeHTMLRequest(f"https://www.{domain}&q={query}&start={p}&lr={lang}&safe={safe}")
+            soup = makeHTMLRequest(f"https://www.{domain}&q={quote(query)}&start={p}&lr={lang}&safe={safe}")
         else:
             return "Invalid search type"
     except Exception as e:

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -15,7 +15,7 @@ def torrentResults(query) -> Response:
         api = request.args.get("api", "false")
 
         # grab & format webpage
-        soup = makeHTMLRequest(f"https://{TORRENTGALAXY_DOMAIN}/torrents.php?search={query}#results")
+        soup = makeHTMLRequest(f"https://{TORRENTGALAXY_DOMAIN}/torrents.php?search={quote(query)}#results")
 
         result_divs = soup.findAll("div", {"class": "tgxtablerow"})
         title = [div.find("div", {"id": "click"}) for div in result_divs]

--- a/src/torrents.py
+++ b/src/torrents.py
@@ -1,5 +1,6 @@
 from src.helpers import makeHTMLRequest, latest_commit
 from _config import *
+from urllib.parse import quote
 from flask import request, render_template, jsonify, Response
 import time
 

--- a/src/video.py
+++ b/src/video.py
@@ -13,7 +13,7 @@ def videoResults(query) -> Response:
     api = request.args.get("api", "false")
 
     # grab & format webpage
-    soup = makeHTMLRequest(f"https://{INVIDIOUS_INSTANCE}/api/v1/search?q={query}")
+    soup = makeHTMLRequest(f"https://{INVIDIOUS_INSTANCE}/api/v1/search?q={quote(query)}")
     data = json.loads(soup.text)
 
     # sort by videos only

--- a/src/video.py
+++ b/src/video.py
@@ -4,6 +4,7 @@ from flask import request, render_template, jsonify, Response
 import time
 import json
 from src.helpers import latest_commit
+from urllib.parse import quote
 
 
 def videoResults(query) -> Response:


### PR DESCRIPTION
If you search something like `& bitwise operator`, it doesn't work, since it thinks that `&` is adding an extra URL parameter. This fixes it by quoting it.
It also prevents a lot of XSS attacks, since the user doesn't control the URL that the server requests.